### PR TITLE
Tracing and autoinstrumentation

### DIFF
--- a/TrainingDriver.py
+++ b/TrainingDriver.py
@@ -17,7 +17,7 @@ from mpi_learn.train.algo import Algo
 from mpi_learn.train.data import H5Data
 from mpi_learn.train.model import ModelFromJson, ModelTensorFlow, ModelPytorch
 from mpi_learn.utils import import_keras
-from mpi_learn.train.trace import Trace
+from mpi_learn.train.timeline import Timeline
 from mpi_learn.logger import initialize_logger
 
 def make_Block_Parser():
@@ -69,7 +69,7 @@ def add_target_options(parser):
 
 def make_train_parser():
     parser = argparse.ArgumentParser()    
-    parser.add_argument('--trace',help='Record timeline of activity', action='store_true')
+    parser.add_argument('--timeline',help='Record timeline of activity', action='store_true')
     add_train_options(parser)
 
     return parser
@@ -201,7 +201,7 @@ if __name__ == '__main__':
         
     comm = MPI.COMM_WORLD.Dup()
 
-    if args.trace: Trace.enable()
+    if args.timeline: Timeline.enable()
 
     model_weights = None
     use_tf = a_backend == 'keras'
@@ -300,4 +300,4 @@ if __name__ == '__main__':
 
     comm.barrier()
     logging.info("Terminating")
-    if args.trace: Trace.collect(clean=True)
+    if args.timeline: Timeline.collect(clean=True)

--- a/mpi_learn/logger.py
+++ b/mpi_learn/logger.py
@@ -2,9 +2,16 @@ from mpi4py import MPI
 import time
 import logging
 from os.path import abspath
+from functools import wraps
+import inspect
+import importlib
+import numpy as np
+import re
+
+TRACE = logging.DEBUG - 5
 
 level_map = {
-    'trace': logging.DEBUG - 5,
+    'trace': TRACE,
     'debug': logging.DEBUG,
     'info': logging.INFO,
     'warn': logging.WARNING,
@@ -53,7 +60,7 @@ class ElapsedTimeFormatter(logging.Formatter):
     def formatTime(self, record, datefmt=None):
         global start_time
         total_millis = int(record.created - start_time) * 1000 + int(record.msecs)
-        
+
         millis = total_millis%1000
         millis = int(millis)
         seconds=(total_millis/1000)%60
@@ -108,7 +115,7 @@ class MPIFileHandler(logging.FileHandler):
 def initialize_logger(filename=None, file_level='info', stream=True, stream_level='info'):
     global file_handler
     global stream_handler
-    addLoggingLevel('TRACE', get_log_level('trace'))
+    addLoggingLevel('TRACE', TRACE)
     logger = logging.getLogger()
     logger.setLevel(min(get_log_level(file_level), get_log_level(stream_level))) # Lowest level that will be propagated to handlers
     logger.handlers = []
@@ -121,6 +128,9 @@ def initialize_logger(filename=None, file_level='info', stream=True, stream_leve
         stream_handler.setLevel(get_log_level(stream_level))
         logger.addHandler(stream_handler)
     set_logging_prefix(MPI.COMM_WORLD.rank)
+    if file_level == 'trace' or stream_level == 'trace':
+        # Disable tracing of optimize for now
+        add_trace_decorators(train=True, mpi=True, optimize=False)
 
 def get_log_level(levelstr='info'):
     levelstr = levelstr.lower()
@@ -138,3 +148,84 @@ def set_logging_prefix(world_rank, parent_rank='-', process_rank='-', process_ty
 
 def get_logger():
     return logging.getLogger()
+
+def add_trace_decorators(train=True, mpi=True, optimize=False):
+    train_module_names = ['algo', 'data', 'model', 'optimizer']
+    mpi_module_names = ['manager', 'process', 'single_process']
+    optimize_module_names = ['coordinator', 'process_block']
+
+    if train:
+        for mod_name in train_module_names:
+            mod = importlib.import_module('..train.' + mod_name, package=__name__)
+            _decorate_module(mod)
+
+    if mpi:
+        for mod_name in mpi_module_names:
+            mod = importlib.import_module('..mpi.' + mod_name, package=__name__)
+            _decorate_module(mod)
+
+    #if optimize:
+    #    for mod_name in optimize_module_names:
+    #        mod = importlib.import_module('..optimize.' + mod_name, package=__name__)
+    #        _decorate_module(mod)
+
+def _decorate_module(mod):
+    # Module-level functions
+    tl_func_list = inspect.getmembers(mod, inspect.isfunction)
+    for name, func in tl_func_list:
+        skip = False
+        for regex in skip_trace:
+            if re.search(regex, func.__qualname__) is not None:
+                skip = True
+                break
+        if skip:
+            logging.log(TRACE, "Skipping tracing of {}".format(func.__qualname__))
+        else:
+            setattr(mod, name, _trace(func))
+    # Class functions
+    cls_list = inspect.getmembers(mod, inspect.isclass)
+    for _, clazz in cls_list:
+        cls_func_list = inspect.getmembers(clazz, lambda x: inspect.isfunction(x) or inspect.ismethod(x))
+        logging.log(TRACE, "Class {} function list {}".format(clazz.__name__, cls_func_list))
+        for fname, func in cls_func_list:
+            skip = False
+            for regex in skip_trace:
+                if re.search(regex, func.__qualname__) is not None:
+                    skip = True
+                    break
+            if skip:
+                logging.log(TRACE, "Skipping tracing of {}".format(func.__qualname__))
+            else:
+                setattr(clazz, fname, _trace(func))
+
+
+skip_trace = [
+    'Monitor.*',
+    'Timeline.*',
+    'Data.is_numpy_array',
+    'MPIProcess.lookup_mpi_tag',
+    'Thread.*'
+]
+
+def _trace(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        def str_type(obj):
+            if type(obj) == list:
+                return 'list[{}]'.format(len(obj))
+            elif isinstance(obj, np.ndarray):
+                return 'ndarray[{}]'.format(obj.shape)
+            else:
+                return str(obj)
+        real_args = args[1:] if '.' in function.__qualname__ else args
+        print_args = [str_type(arg) for arg in real_args]
+        print_kwargs = ['{}={}'.format(k, str_type(v)) for k, v in kwargs.items()]
+        params = ', '.join(print_args + print_kwargs)
+        logging.log(TRACE, '>>> {}.{}({})'.format(function.__module__, function.__qualname__, params))
+
+        ret_val = function(*args, **kwargs)
+
+        logging.log(TRACE, '<<< {}.{}'.format(function.__module__, function.__qualname__))
+        return ret_val
+
+    return wrapper

--- a/mpi_learn/mpi/manager.py
+++ b/mpi_learn/mpi/manager.py
@@ -217,9 +217,9 @@ class MPIManager(object):
             ids = self.comm_instance.allgather( self.worker_id )
             self.worker_id = list(filter(lambda i:i!=-1, ids))[0]
 
-        logging.debug("master comm",self.comm_masters.Get_size() if self.comm_masters else "N/A")
-        logging.debug("block comm",self.comm_block.Get_size() if self.comm_block else "N/A")
-        logging.debug("instance comm",self.comm_instance.Get_size() if self.comm_instance else "N/A")
+        logging.debug("Master communicator size: {}".format(self.comm_masters.Get_size() if self.comm_masters else "N/A"))
+        logging.debug("Block communicator size: {}".format(self.comm_block.Get_size() if self.comm_block else "N/A"))
+        logging.debug("Instance communicator size: {}".format(self.comm_instance.Get_size() if self.comm_instance else "N/A"))
         
         # Case (1)
         if self.num_masters > 1:

--- a/mpi_learn/train/algo.py
+++ b/mpi_learn/train/algo.py
@@ -92,9 +92,8 @@ class Algo(object):
         return config
 
     def __str__(self):
-        strs = [ "optimizer: "+str(self.optimizer_name) ]
-        strs += [ opt+": "+str(getattr(self, opt)) for opt in self.supported_opts ]
-        return '\n'.join(strs)
+        params = [ "{}={!s}".format(opt, getattr(self, opt)) for opt in self.supported_opts ]
+        return "Algo(optimizer={}, {})".format(self.optimizer_name, ",".join(params))
 
     ### For Worker ###
 

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -359,13 +359,8 @@ class TFOptimizer(Optimizer):
 
         gradient_dict = {placeholder : value for placeholder, value in zip(self.gradient, gradient)}
 
-        #Trace.begin("tf_optimizer")
         self.sess.run(self.optimizer_op, feed_dict=gradient_dict)
-        #Trace.end("tf_optimizer")
-
-        #Trace.begin("tf_get_weights")
         res = self.sess.run(self.weights)
-        #Trace.end("tf_get_weights")
 
         return res
 

--- a/mpi_learn/train/timeline.py
+++ b/mpi_learn/train/timeline.py
@@ -5,21 +5,21 @@ import json
 from functools import wraps
 from mpi4py import MPI
 
-def trace(original_function=None, category=None, **decorator_kwargs):
+def timeline(original_function=None, category=None, **decorator_kwargs):
     """Decorates a function. Can be called with or without additional arguments. Name of event is the name of decorated function.
         Params:
-          category: Optional category of event (useful to show/hide category of events in trace viewer)
+          category: Optional category of event (useful to show/hide category of events in timeline viewer)
           decorator_kwargs: Additional arguments
     """
     def _decorate(function):
         @wraps(function)
         def wrapped_function(*args, **kwargs):
-            Trace.begin(function.__name__, category, **decorator_kwargs)
+            Timeline.begin(function.__name__, category, **decorator_kwargs)
             if len(args) == 1 and not kwargs and callable(args[0]):
                 ret_val = function()(args[0])
             else:
                 ret_val = function(*args, **kwargs)
-            Trace.end(function.__name__, category, **decorator_kwargs)
+            Timeline.end(function.__name__, category, **decorator_kwargs)
             return ret_val
 
         return wrapped_function
@@ -29,7 +29,7 @@ def trace(original_function=None, category=None, **decorator_kwargs):
 
     return _decorate
 
-class Trace(object):
+class Timeline(object):
     """ Class that traces events to display on timeline """
     _enabled = False
     _events = []
@@ -38,7 +38,7 @@ class Trace(object):
     _flush_every = 100
 
     @classmethod
-    def _trace(cls, event_name, type, category=None, **kwargs):
+    def _record(cls, event_name, type, category=None, **kwargs):
         if cls._enabled:
             ts = int(round(time.time() * 1000000))
             if category is None: category = "TRACE"
@@ -50,8 +50,8 @@ class Trace(object):
 
             # Write events to process-specific file (in case collect() is never called)
             if cls._flush_every > 0 and len(cls._events) % cls._flush_every == 0:
-                with open(cls._process_file, 'a+') as trace_file:
-                    trace_file.write(",\n".join(map(json.dumps, cls._events[-cls._flush_every:])))
+                with open(cls._process_file, 'a+') as timeline_file:
+                    timeline_file.write(",\n".join(map(json.dumps, cls._events[-cls._flush_every:])))
 
     @classmethod
     def begin(cls, name, category=None, **kwargs):
@@ -61,7 +61,7 @@ class Trace(object):
               category: Optional category of event (useful to show/hide category of events in trace viewer)
               kwargs: Additional arguments
         """
-        cls._trace(name, "B", category, **kwargs)
+        cls._record(name, "B", category, **kwargs)
     
     @classmethod
     def end(cls, name, category=None, **kwargs):
@@ -71,17 +71,17 @@ class Trace(object):
               category: Optional category of event (useful to show/hide category of events in trace viewer)
               kwargs: Additional arguments
         """
-        cls._trace(name, "E", category, **kwargs)
+        cls._record(name, "E", category, **kwargs)
 
     @classmethod
     def enable(cls, flush_file=None, flush_every=100):
-        """Enables collection of trace events.
+        """Enables collection of timeline events.
             Params:
-              flush_file: name of per-process trace file to temporarily write events to, if None, 'str(os.getpid()) + _trace.json' is used
+              flush_file: name of per-process timeline file to temporarily write events to, if None, 'str(os.getpid()) + _timeline.json' is used
               flush_every: Number of events to collect before flushing them to temporary file. 0 disables writing.
         """
         cls._enabled = True
-        cls._process_file = flush_file or str(os.getpid()) + "_trace.json"
+        cls._process_file = flush_file or str(os.getpid()) + "_timeline.json"
         cls._flush_every = flush_every
 
     @classmethod
@@ -94,10 +94,10 @@ class Trace(object):
 
     @classmethod
     def collect(cls, file_name=None, clean=False, comm=None):
-        """Collects events from processes and writes them to a trace file.
+        """Collects events from processes and writes them to a timeline file.
             Params:
-              file_name: name of trace file to write events to, if None, 'mpi_learn_trace.json' is used
-              clean: If True, removes process-specific temporary trace files
+              file_name: name of timeline file to write events to, if None, 'nnlo_timeline.json' is used
+              clean: If True, removes process-specific temporary timeline files
               comm: MPI communicator to use, if None, MPI.COMM_WORLD is used 
         """
         if not cls._enabled:
@@ -107,7 +107,7 @@ class Trace(object):
         all_events = comm.gather(cls._events, root=0)
 
         if (comm.Get_rank() == 0):
-            with open(file_name or "mpi_learn_trace.json", 'w+') as master_file:
+            with open(file_name or "nnlo_timeline.json", 'w+') as master_file:
                 master_file.write("[\n")
                 flat_events = []
                 for events in all_events:


### PR DESCRIPTION
Adds new log level, `TRACE`, enabled via `--log-level trace`. Tracing will record all function enter and exit events, as well as the parameters that were passed to the function. There is a mechanism to skip tracing of some functions (like simple lookup functions that would spam the log).