### PR TITLE
enable tf opt for OptimizationDriver

### DIFF
--- a/MPIGDriver.py
+++ b/MPIGDriver.py
@@ -125,8 +125,7 @@ if __name__ == '__main__':
 
     if use_tf:
         from nnlo.train.GanModel import GANModelBuilder
-        model_builder  = GANModelBuilder( comm , device_name=device, tf= True, weights=model_weights)
-        logging.info("Process {0} using device {1}".format(comm.Get_rank(), model_builder.device))
+        model_builder  = GANModelBuilder( comm , tf= True, weights=model_weights)
 
 
     data = H5Data( batch_size=args.batch,

--- a/OptimizationDriver.py
+++ b/OptimizationDriver.py
@@ -140,7 +140,8 @@ if __name__ == '__main__':
         MPI.COMM_WORLD.Abort()
 
     block_num = get_block_num(comm_world, args.block_size)
-    device = get_device(comm_world, num_blocks)
+    device = get_device(comm_world, num_blocks,
+                        gpu_limit=args.max_gpus)
     logging.info("Process {} using device {}".format(comm_world.Get_rank(), device))
 
     os.environ['CUDA_VISIBLE_DEVICES'] = device[-1] if 'gpu' in device else ''

--- a/TrainingDriver.py
+++ b/TrainingDriver.py
@@ -266,10 +266,7 @@ if __name__ == '__main__':
             allow_soft_placement=True, log_device_placement=False,
             gpu_options=gpu_options
         ) ) )
-        tf_device = device
-        tf_device = 'gpu0' if 'gpu' in device else ''
-        model_builder = ModelTensorFlow( comm, source=args.model, device_name=tf_device , weights=model_weights)
-        logging.debug("Using device {}".format(model_builder.device))
+        model_builder = ModelTensorFlow( comm, source=args.model, weights=model_weights)
 
 
     data = make_loader(args, features_name, labels_name, train_list)

--- a/TrainingDriver.py
+++ b/TrainingDriver.py
@@ -168,8 +168,7 @@ def make_algo( args, use_tf, comm, validate_every ):
     args_opt = args.optimizer
     if use_tf:
         if not args_opt.endswith("tf"):
-            #args_opt = args_opt + 'tf'
-            pass
+            args_opt = args_opt + 'tf'
     else:
         if not args_opt.endswith("torch"):
             args_opt = args_opt + 'torch'

--- a/TrainingDriver.py
+++ b/TrainingDriver.py
@@ -107,8 +107,7 @@ def add_train_options(parser):
     # configuration of network topology
     parser.add_argument('--n-masters', dest='n_masters', help='number of master processes', default=1, type=int)
     parser.add_argument('--n-processes', dest='n_processes', help='number of processes per worker', default=1, type=int)
-    parser.add_argument('--max-gpus', dest='max_gpus', help='max GPUs to use', 
-            type=int, default=-1)
+    parser.add_argument('--max-gpus', dest='max_gpus', help='max GPUs to use', type=int, default=1)
 
 
     # configuration of training process

--- a/nnlo/mpi/manager.py
+++ b/nnlo/mpi/manager.py
@@ -62,18 +62,18 @@ def get_device(comm, num_masters=1, gpu_limit=-1, gpu_for_master=False):
     for inode in range( comm.Get_size()):
         if rank == inode:
             gpu_list = get_gpu_list()
-            if gpu_limit>=0:
-                gpu_list = gpu_list[:gpu_limit] #limit the number of gpu
+            #if gpu_limit>=0:
+            #    gpu_list = gpu_list[:gpu_limit] #limit the number of gpu
             if len(gpu_list) == 0:
                 logging.info("No free GPU available. Using CPU instead.")
                 dev = 'cpu'
             elif worker_id<0:
                 ## alone on that machine
-                logging.info("Alone on the node and taking the last gpu")
                 dev = 'gpu%d' % (gpu_list[-1])
+                logging.info("Alone on the node and taking the last gpu {}".format(dev))
             else:
-                logging.debug("Sharing a node and taking on the gpu")
                 dev = 'gpu%d' % (gpu_list[worker_id%len(gpu_list)])
+                logging.info("Sharing a node and taking on the gpu {}".format(dev))                
             logging.debug("rank %d can have %s",rank,dev)
         comm.Barrier()
     return dev

--- a/nnlo/mpi/manager.py
+++ b/nnlo/mpi/manager.py
@@ -61,7 +61,7 @@ def get_device(comm, num_masters=1, gpu_limit=-1, gpu_for_master=False):
     
     for inode in range( comm.Get_size()):
         if rank == inode:
-            gpu_list = get_gpu_list()
+            gpu_list = get_gpu_list() if gpu_limit else []
             #if gpu_limit>=0:
             #    gpu_list = gpu_list[:gpu_limit] #limit the number of gpu
             if len(gpu_list) == 0:

--- a/nnlo/optimize/process_block.py
+++ b/nnlo/optimize/process_block.py
@@ -81,7 +81,6 @@ class ProcessBlock(object):
             model_builder = self.model_provider.builder(*params)
             if model_builder:
                 model_builder.comm = self.comm_block
-                model_builder.device = model_builder.get_device_name(self.device)
                 self.current_builder = model_builder
             else:
                 self.current_builder = None

--- a/nnlo/train/GanModel.py
+++ b/nnlo/train/GanModel.py
@@ -30,7 +30,6 @@ from keras.layers.advanced_activations import LeakyReLU
 from keras.layers.convolutional import (UpSampling3D, Conv3D, ZeroPadding3D,
                                         AveragePooling3D)
 
-from ..util.utils import get_device_name
 from ..train.model import MPIModel, ModelBuilder
 from .optimizer import OptimizerBuilder
 
@@ -979,12 +978,10 @@ class GANModel(MPIModel):
 
 
 class GANModelBuilder(ModelBuilder):
-    def __init__(self, c, device_name='cpu',tf=False, weights=None):
+    def __init__(self, c, tf=False, weights=None):
         ModelBuilder.__init__(self, c )
         self.tf = tf
         self.weights = weights# the prefix for the weights
-        #self.weights = weights.split(',') if weights else list([None,None])
-        self.device = self.get_device_name(device_name) if self.tf else None
         self.model_parameters={}
         
     def get_backend_name(self):
@@ -1004,26 +1001,6 @@ class GANModelBuilder(ModelBuilder):
                 logging.info("Restoring weights from {}".format(w_file))
                 mm.load_weights( w_file )
         return m
-
-    def get_device_name(self, device):
-        """Returns a TF-style device identifier for the specified device.
-            input: 'cpu' for CPU and 'gpuN' for the Nth GPU on the host"""
-        if device == 'cpu':
-            dev_num = 0
-            dev_type = 'cpu'
-        elif device.startswith('gpu'):
-            try:
-                dev_num = int(device[3:])
-                dev_type = 'gpu'
-            except ValueError:
-                print ("GPU number could not be parsed from {}; using CPU".format(device))
-                dev_num = 0
-                dev_type = 'cpu'
-        else:
-            print ("Please specify 'cpu' or 'gpuN' for device name")
-            dev_num = 0
-            dev_type = 'cpu'
-        return get_device_name(dev_type, dev_num, backend='tensorflow')
 
 class GANBuilder(object):
     def __init__(self, parameters):

--- a/nnlo/util/utils.py
+++ b/nnlo/util/utils.py
@@ -27,17 +27,6 @@ def opt_tag_lookup(tag):
             }
     return tags.get(tag, 0)
 
-def get_device_name(dev_type, dev_num, backend='theano'):
-    """Returns cpu/gpu device name formatted for
-    theano or keras, as specified by the backend argument"""
-    if backend == 'tensorflow':
-        return "/%s:%d" % (dev_type, dev_num)
-    else:
-        if dev_type == 'cpu':
-            return 'cpu'
-        else:
-            return dev_type+str(dev_num)
-
 def import_keras(tries=10):
     """There is an issue when multiple processes import Keras simultaneously --
         the file .keras/keras.json is sometimes not read correctly.  


### PR DESCRIPTION
with this done

`mpirun -np 3 --tag-output python3 TrainingDriver.py --model examples/example_mnist.py --loss categorical_crossentropy --epochs 3`

goes through, while 

`mpirun -np 7 --tag-output python3 OptimizationDriver.py --model examples/example_mnist.py --block-size 3 --epochs 3 --num-iterations 10`

bombs on 

> [1,4]<stderr>:InvalidArgumentError (see above for traceback): Cannot assign a device for operation 'dense_2_1/bias': Operation was explicitly assigned to /device:GPU:4 but available devices are [ /job:localhost/replica:0/task:0/cpu:0, /job:localhost/replica:0/task:0/gpu:0 ]. Make sure the device specification refers to a valid device.
> [1,4]<stderr>:	 [[Node: dense_2_1/bias = VariableV2[container="", dtype=DT_FLOAT, shape=[10], shared_name="", _device="/device:GPU:4"]()]]

with a stack that points at

> [1,4]<stderr>:    super(AdamTF, self).setup_update(weights)

